### PR TITLE
feat: error modal, persistent logs, dashboard viewport, question modal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ charm.land/bubbletea/v2 v2.0.1 h1:B8e9zzK7x9JJ+XvHGF4xnYu9Xa0E0y0MyggY6dbaCfQ=
 charm.land/bubbletea/v2 v2.0.1/go.mod h1:3LRff2U4WIYXy7MTxfbAQ+AdfM3D8Xuvz2wbsOD9OHQ=
 charm.land/lipgloss/v2 v2.0.0 h1:sd8N/B3x892oiOjFfBQdXBQp3cAkvjGaU5TvVZC3ivo=
 charm.land/lipgloss/v2 v2.0.0/go.mod h1:w6SnmsBFBmEFBodiEDurGS/sdUY/u1+v72DqUzc6J14=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=
@@ -52,6 +54,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -52,9 +52,10 @@ type Loop struct {
 	events          chan Event
 	geminiCmd       *exec.Cmd
 	logFile         *os.File
-	mu              sync.Mutex
-	stopped         bool
-	paused          bool
+	mu                 sync.Mutex
+	stopped            bool
+	paused             bool
+	rateLimitStopped   bool
 	retryConfig     RetryConfig
 	lastOutputTime  time.Time
 	watchdogTimeout time.Duration
@@ -363,6 +364,7 @@ func (l *Loop) runIteration(ctx context.Context) error {
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
+		rateLimitSent := false
 		scanner := bufio.NewScanner(stderr)
 		scanner.Buffer(make([]byte, 256*1024), 256*1024)
 		for scanner.Scan() {
@@ -373,9 +375,13 @@ func (l *Loop) runIteration(ctx context.Context) error {
 			l.mu.Unlock()
 			// Emit stderr event so TUI can show it
 			l.events <- Event{Type: EventStderr, Iteration: iter, Text: line}
-			// Detect rate-limit / quota errors; emit a dedicated event and stop the loop
-			if IsRateLimitLine(line) {
+			// Detect rate-limit / quota errors; emit a dedicated event and stop the loop (once)
+			if !rateLimitSent && IsRateLimitLine(line) {
+				rateLimitSent = true
 				l.events <- Event{Type: EventRateLimit, Iteration: iter, Text: line}
+				l.mu.Lock()
+				l.rateLimitStopped = true
+				l.mu.Unlock()
 				l.Stop()
 			}
 			// Keep last 10 lines for error context
@@ -427,6 +433,12 @@ func (l *Loop) runIteration(ctx context.Context) error {
 			return fmt.Errorf("watchdog timeout: no output for %s", l.watchdogTimeout)
 		}
 		if stopped {
+			l.mu.Lock()
+			rl := l.rateLimitStopped
+			l.mu.Unlock()
+			if rl {
+				return fmt.Errorf("rate limit / quota exceeded")
+			}
 			return nil
 		}
 		// Build error with stderr context

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -368,11 +368,21 @@ func (l *Loop) runIteration(ctx context.Context) error {
 		for scanner.Scan() {
 			line := scanner.Text()
 			l.logLine("[stderr] " + line)
-			// Emit stderr as events so TUI can show them
 			l.mu.Lock()
 			iter := l.iteration
 			l.mu.Unlock()
+			// Emit stderr event so TUI can show it
 			l.events <- Event{Type: EventStderr, Iteration: iter, Text: line}
+			// Detect rate-limit / quota errors; emit a dedicated event and stop the loop
+			lower := strings.ToLower(line)
+			if strings.Contains(lower, "rate limit") ||
+				strings.Contains(lower, "ratelimit") ||
+				strings.Contains(lower, "quota") ||
+				strings.Contains(lower, "429") ||
+				strings.Contains(lower, "resource exhausted") {
+				l.events <- Event{Type: EventRateLimit, Iteration: iter, Text: line}
+				l.Stop()
+			}
 			// Keep last 10 lines for error context
 			stderrMu.Lock()
 			stderrLines = append(stderrLines, line)

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -374,12 +374,7 @@ func (l *Loop) runIteration(ctx context.Context) error {
 			// Emit stderr event so TUI can show it
 			l.events <- Event{Type: EventStderr, Iteration: iter, Text: line}
 			// Detect rate-limit / quota errors; emit a dedicated event and stop the loop
-			lower := strings.ToLower(line)
-			if strings.Contains(lower, "rate limit") ||
-				strings.Contains(lower, "ratelimit") ||
-				strings.Contains(lower, "quota") ||
-				strings.Contains(lower, "429") ||
-				strings.Contains(lower, "resource exhausted") {
+			if IsRateLimitLine(line) {
 				l.events <- Event{Type: EventRateLimit, Iteration: iter, Text: line}
 				l.Stop()
 			}
@@ -445,6 +440,23 @@ func (l *Loop) runIteration(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// IsRateLimitLine returns true if a stderr line indicates a rate-limit or quota error.
+// It uses specific patterns to avoid false positives from file paths, ports, or memory addresses
+// that happen to contain "429".
+func IsRateLimitLine(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "rate limit") ||
+		strings.Contains(lower, "ratelimit") ||
+		strings.Contains(lower, "quota") ||
+		strings.Contains(lower, "resource exhausted") ||
+		strings.Contains(lower, "http 429") ||
+		strings.Contains(lower, "status 429") ||
+		strings.Contains(lower, "code 429") ||
+		strings.Contains(lower, "error 429") ||
+		strings.Contains(lower, "429 too many") ||
+		strings.Contains(lower, "429 resource")
 }
 
 // IsErrorLine returns true if a stderr line contains error-relevant content.

--- a/internal/loop/loop_test.go
+++ b/internal/loop/loop_test.go
@@ -628,6 +628,48 @@ func TestLoop_WatchdogReturnsError(t *testing.T) {
 	}
 }
 
+// ── Fix 3: Tighten 429 match ─────────────────────────────────────────────────
+
+func TestIsRateLimitLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// True positives — should match
+		{"HTTP 429", "HTTP 429 Too Many Requests", true},
+		{"status 429", "Error: status 429", true},
+		{"code 429", "response code 429", true},
+		{"error 429", "error 429 from API", true},
+		{"429 too many", "429 Too Many Requests", true},
+		{"429 resource", "429 Resource Exhausted", true},
+		{"rate limit", "You have exceeded the rate limit", true},
+		{"ratelimit", "RateLimitError: too many requests", true},
+		{"quota", "Quota exceeded for project", true},
+		{"resource exhausted", "RESOURCE_EXHAUSTED: quota", true},
+		{"mixed case", "HTTP 429 too many requests", true},
+
+		// False positives — should NOT match
+		{"file path with 429", "Reading file_429.txt", false},
+		{"port 4290", "Server listening on port 4290", false},
+		{"memory address", "allocated at 0x429abc", false},
+		{"line number 429", "  429: func main() {", false},
+		{"year 1429", "Founded in 1429", false},
+		{"version 4.2.9", "Updated to version 4.2.9", false},
+		{"plain text", "Everything is working fine", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRateLimitLine(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsRateLimitLine(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 // TestLoop_WatchdogWithWorkDir tests that watchdog works with NewLoopWithWorkDir too.
 func TestLoop_WatchdogWithWorkDir(t *testing.T) {
 	l := NewLoopWithWorkDir("/test/prd.json", "/work", "test", 5)

--- a/internal/loop/parser.go
+++ b/internal/loop/parser.go
@@ -37,6 +37,9 @@ const (
 	EventStdout
 	// EventStderr is emitted for raw stderr lines.
 	EventStderr
+	// EventRateLimit is emitted when Gemini hits a rate-limit / quota error in stderr.
+	// The loop stops automatically; the TUI should offer the user options.
+	EventRateLimit
 )
 
 // String returns the string representation of an EventType.
@@ -68,6 +71,8 @@ func (e EventType) String() string {
 		return "Stdout"
 	case EventStderr:
 		return "Stderr"
+	case EventRateLimit:
+		return "RateLimit"
 	default:
 		return "Unknown"
 	}

--- a/internal/loop/parser.go
+++ b/internal/loop/parser.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -151,9 +152,7 @@ func ParseLine(line string) *Event {
 		return parseUserMessage(msg.Message)
 
 	case "result":
-		// Result messages indicate the end of an iteration
-		// We don't emit a specific event for this, but could in the future
-		return nil
+		return parseResultMessage(line)
 
 	default:
 		return nil
@@ -230,6 +229,29 @@ func parseUserMessage(raw json.RawMessage) *Event {
 		}
 	}
 
+	return nil
+}
+
+// parseResultMessage parses a result event. Gemini emits these at the end of a
+// turn — when status is "error" we surface the API error message.
+func parseResultMessage(line string) *Event {
+	var raw struct {
+		Status string `json:"status"`
+		Error  struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return nil
+	}
+	if raw.Status == "error" && raw.Error.Message != "" {
+		return &Event{
+			Type: EventError,
+			Text: raw.Error.Message,
+			Err:  fmt.Errorf("Gemini API error: %s", raw.Error.Message),
+		}
+	}
 	return nil
 }
 

--- a/internal/prd/watcher_test.go
+++ b/internal/prd/watcher_test.go
@@ -102,6 +102,7 @@ func TestWatcherDetectsFileChange(t *testing.T) {
 	if err := os.WriteFile(prdPath, data, 0644); err != nil {
 		t.Fatalf("Failed to update test PRD: %v", err)
 	}
+	time.Sleep(50 * time.Millisecond) // Ensure file write completes before watcher processes it
 
 	// Wait for the event
 	select {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1132,11 +1132,8 @@ func (a App) handleLoopEvent(prdName string, event loop.Event) (tea.Model, tea.C
 		a.iteration = event.Iteration
 		// Add event to log viewer and persist to disk
 		a.logViewer.AddEvent(event)
-		if len(a.logViewer.entries) > 0 {
-			_ = a.logViewer.AppendEntry(
-				tuiLogPath(a.prdPath),
-				a.logViewer.entries[len(a.logViewer.entries)-1],
-			)
+		if entry, ok := a.logViewer.LastEntry(); ok {
+			_ = a.logViewer.AppendEntry(tuiLogPath(a.prdPath), entry)
 		}
 	}
 
@@ -2511,6 +2508,9 @@ func (a App) switchToPRD(name, prdPath string) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Persist the current PRD's log to disk before clearing (must use OLD prdPath)
+	_ = a.logViewer.SaveEntries(tuiLogPath(a.prdPath))
+
 	// Update app state
 	a.prd = newPRD
 	a.prdPath = prdPath
@@ -2535,14 +2535,14 @@ func (a App) switchToPRD(name, prdPath string) (tea.Model, tea.Cmd) {
 	a.tabBar.SetActiveByName(name)
 	a.tabBar.Refresh()
 
-	// Persist the current PRD's log to disk before clearing
-	_ = a.logViewer.SaveEntries(tuiLogPath(a.prdPath))
-
 	// Clear log viewer and story timing (each PRD has its own log/timing)
 	a.logViewer.Clear()
 
-	// Restore any previously-saved log for the new PRD
+	// Restore any previously-saved log for the new PRD, then rewrite
+	// the file to match in-memory state (prevents duplicates from
+	// filtered events or append-after-load races).
 	_ = a.logViewer.LoadEntries(tuiLogPath(prdPath))
+	_ = a.logViewer.SaveEntries(tuiLogPath(prdPath))
 
 	a.storyTimings = nil
 	a.currentStoryID = ""

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/bubbles/v2/viewport"
 	"github.com/lvcoi/melliza/embed"
 	"github.com/lvcoi/melliza/internal/config"
 	"github.com/lvcoi/melliza/internal/git"
@@ -163,6 +164,7 @@ const (
 	ViewSettings
 	ViewQuitConfirm
 	ViewPRDCreationChat
+	ViewErrorModal
 )
 
 // App is the main Bubble Tea model for the Melliza TUI.
@@ -175,7 +177,7 @@ type App struct {
 	startTime     time.Time
 	selectedIndex       int
 	storiesScrollOffset int
-	detailsScrollOffset int
+	detailsVP           viewport.Model
 	width              int
 	height             int
 	err           error
@@ -234,6 +236,10 @@ type App struct {
 
 	// Quit confirmation dialog
 	quitConfirm *QuitConfirmation
+
+	// Error modal (shown after 3 consecutive failures without progress)
+	errorModal       *ErrorModal
+	consecutiveErrors map[string]int // per PRD name
 
 	// PRD creation chat
 	creationChat *PRDCreationChat
@@ -322,6 +328,10 @@ func NewAppWithOptions(prdPath string, maxIter int) (*App, error) {
 	// Create picker with manager reference (for creating new PRDs)
 	picker := NewPRDPicker(baseDir, prdName, manager)
 
+	detailsVP := viewport.New()
+	detailsVP.MouseWheelEnabled = false
+	detailsVP.KeyMap = viewport.KeyMap{}
+
 	return &App{
 		prd:           p,
 		prdPath:       prdPath,
@@ -330,6 +340,7 @@ func NewAppWithOptions(prdPath string, maxIter int) (*App, error) {
 		iteration:     0,
 		selectedIndex: 0,
 		maxIter:       maxIter,
+		detailsVP:     detailsVP,
 		manager:       manager,
 		watcher:         watcher,
 		progressWatcher: progressWatcher,
@@ -345,8 +356,10 @@ func NewAppWithOptions(prdPath string, maxIter int) (*App, error) {
 		branchWarning:    NewBranchWarning(),
 		worktreeSpinner:  NewWorktreeSpinner(),
 		completionScreen: NewCompletionScreen(),
-		settingsOverlay:  NewSettingsOverlay(),
-		quitConfirm:     NewQuitConfirmation(),
+		settingsOverlay:   NewSettingsOverlay(),
+		quitConfirm:      NewQuitConfirmation(),
+		errorModal:       NewErrorModal(),
+		consecutiveErrors: make(map[string]int),
 	}, nil
 }
 
@@ -682,6 +695,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a.handleQuitConfirmKeys(msg)
 		}
 
+		// Handle error modal
+		if a.viewMode == ViewErrorModal {
+			return a.handleErrorModalKeys(msg)
+		}
+
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return a.tryQuit()
@@ -781,7 +799,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				if a.prd != nil && a.selectedIndex > 0 {
 					a.selectedIndex--
-					a.detailsScrollOffset = 0
+					a.detailsVP.GotoTop()
 					if a.selectedIndex < a.storiesScrollOffset {
 						a.storiesScrollOffset = a.selectedIndex
 					}
@@ -795,7 +813,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				if a.prd != nil && a.selectedIndex < len(a.prd.UserStories)-1 {
 					a.selectedIndex++
-					a.detailsScrollOffset = 0
+					a.detailsVP.GotoTop()
 					a.adjustStoriesScroll()
 				}
 			}
@@ -807,7 +825,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else if a.viewMode == ViewDiff {
 				a.diffViewer.PageDown()
 			} else if a.viewMode == ViewDashboard {
-				a.detailsScrollOffset += 5
+				a.detailsVP.HalfPageDown()
 			}
 		case "ctrl+u", "pgup":
 			if a.viewMode == ViewLog {
@@ -815,10 +833,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else if a.viewMode == ViewDiff {
 				a.diffViewer.PageUp()
 			} else if a.viewMode == ViewDashboard {
-				a.detailsScrollOffset -= 5
-				if a.detailsScrollOffset < 0 {
-					a.detailsScrollOffset = 0
-				}
+				a.detailsVP.HalfPageUp()
 			}
 		case "g":
 			if a.viewMode == ViewLog {
@@ -1064,6 +1079,50 @@ func (a *App) renderQuitConfirmView() string {
 	return a.quitConfirm.Render()
 }
 
+// tuiLogPath returns the path for the TUI log JSONL file for a given PRD path.
+func tuiLogPath(prdPath string) string {
+	return filepath.Join(filepath.Dir(prdPath), "tui_log.jsonl")
+}
+
+// showErrorModal sets up and opens the error modal overlay.
+func (a *App) showErrorModal(errText string) {
+	a.previousViewMode = a.viewMode
+	a.errorModal.SetError(errText)
+	a.errorModal.SetSize(a.width, a.height)
+	a.viewMode = ViewErrorModal
+}
+
+// handleErrorModalKeys handles keyboard input for the error modal.
+func (a App) handleErrorModalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	updated, cmd := a.errorModal.Update(msg)
+	a.errorModal = updated
+	if !a.errorModal.IsDone() {
+		return a, cmd
+	}
+
+	switch a.errorModal.Choice() {
+	case ErrorChoiceSaveQuit:
+		a.stopAllLoops()
+		a.stopWatcher()
+		return a, tea.Quit
+	case ErrorChoiceStopLoop:
+		if a.manager != nil {
+			_ = a.manager.Stop(a.prdName)
+		}
+		a.viewMode = a.previousViewMode
+		return a, cmd
+	default: // ErrorChoiceContinue / Esc
+		a.viewMode = a.previousViewMode
+		return a, cmd
+	}
+}
+
+// renderErrorModalView renders the error modal overlay.
+func (a *App) renderErrorModalView() string {
+	a.errorModal.SetSize(a.width, a.height)
+	return a.errorModal.Render()
+}
+
 // handleLoopEvent handles events from the manager.
 func (a App) handleLoopEvent(prdName string, event loop.Event) (tea.Model, tea.Cmd) {
 	// Only update iteration and log if this is the currently viewed PRD
@@ -1071,8 +1130,14 @@ func (a App) handleLoopEvent(prdName string, event loop.Event) (tea.Model, tea.C
 
 	if isCurrentPRD {
 		a.iteration = event.Iteration
-		// Add event to log viewer
+		// Add event to log viewer and persist to disk
 		a.logViewer.AddEvent(event)
+		if len(a.logViewer.entries) > 0 {
+			_ = a.logViewer.AppendEntry(
+				tuiLogPath(a.prdPath),
+				a.logViewer.entries[len(a.logViewer.entries)-1],
+			)
+		}
 	}
 
 	var autoActionCmd tea.Cmd
@@ -1109,6 +1174,8 @@ func (a App) handleLoopEvent(prdName string, event loop.Event) (tea.Model, tea.C
 			a.currentStoryStart = time.Now()
 		}
 	case loop.EventStoryCompleted:
+		// Progress was made — reset consecutive error counter for this PRD
+		a.consecutiveErrors[prdName] = 0
 		if isCurrentPRD {
 			label := "✓ " + event.StoryID + " complete"
 			if event.Text != "" {
@@ -1136,12 +1203,28 @@ func (a App) handleLoopEvent(prdName string, event loop.Event) (tea.Model, tea.C
 			a.state = StatePaused
 			a.lastActivity = "Max iterations reached"
 		}
+	case loop.EventRateLimit:
+		// Rate-limit detected — loop already stopped itself; bump the error counter
+		// and show the error modal immediately (rate limits always warrant a popup).
+		a.consecutiveErrors[prdName]++
+		if isCurrentPRD {
+			a.state = StateError
+			a.lastActivity = "⚠ Rate limit / quota exceeded"
+			a.showErrorModal(event.Text)
+		}
 	case loop.EventError:
+		a.consecutiveErrors[prdName]++
 		if isCurrentPRD {
 			a.state = StateError
 			a.err = event.Err
+			errMsg := ""
 			if event.Err != nil {
-				a.lastActivity = "Error: " + event.Err.Error()
+				errMsg = event.Err.Error()
+				a.lastActivity = "Error: " + errMsg
+			}
+			// Show the modal on the 3rd consecutive failure (no story completed between)
+			if a.consecutiveErrors[prdName] >= 3 {
+				a.showErrorModal(errMsg)
 			}
 		}
 	case loop.EventRetrying:
@@ -1259,6 +1342,8 @@ func (a App) View() tea.View {
 		content = a.renderSettingsView()
 	case ViewQuitConfirm:
 		content = a.renderQuitConfirmView()
+	case ViewErrorModal:
+		content = a.renderErrorModalView()
 	case ViewPRDCreationChat:
 		content = a.renderCreationChatView()
 	default:
@@ -2432,6 +2517,7 @@ func (a App) switchToPRD(name, prdPath string) (tea.Model, tea.Cmd) {
 	a.prdName = name
 	a.selectedIndex = 0
 	a.storiesScrollOffset = 0
+	a.detailsVP.GotoTop()
 	a.state = appState
 	a.iteration = iteration
 	a.err = loopErr
@@ -2449,8 +2535,15 @@ func (a App) switchToPRD(name, prdPath string) (tea.Model, tea.Cmd) {
 	a.tabBar.SetActiveByName(name)
 	a.tabBar.Refresh()
 
+	// Persist the current PRD's log to disk before clearing
+	_ = a.logViewer.SaveEntries(tuiLogPath(a.prdPath))
+
 	// Clear log viewer and story timing (each PRD has its own log/timing)
 	a.logViewer.Clear()
+
+	// Restore any previously-saved log for the new PRD
+	_ = a.logViewer.LoadEntries(tuiLogPath(prdPath))
+
 	a.storyTimings = nil
 	a.currentStoryID = ""
 	a.currentStoryStart = time.Time{}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -178,6 +178,7 @@ type App struct {
 	selectedIndex       int
 	storiesScrollOffset int
 	detailsVP           viewport.Model
+	detailsVPContent    string // cached to avoid SetContent scroll-reset in View()
 	width              int
 	height             int
 	err           error
@@ -1109,9 +1110,11 @@ func (a App) handleErrorModalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if a.manager != nil {
 			_ = a.manager.Stop(a.prdName)
 		}
+		a.consecutiveErrors[a.prdName] = 0
 		a.viewMode = a.previousViewMode
 		return a, cmd
 	default: // ErrorChoiceContinue / Esc
+		a.consecutiveErrors[a.prdName] = 0
 		a.viewMode = a.previousViewMode
 		return a, cmd
 	}
@@ -1133,7 +1136,9 @@ func (a App) handleLoopEvent(prdName string, event loop.Event) (tea.Model, tea.C
 		// Add event to log viewer and persist to disk
 		a.logViewer.AddEvent(event)
 		if entry, ok := a.logViewer.LastEntry(); ok {
-			_ = a.logViewer.AppendEntry(tuiLogPath(a.prdPath), entry)
+			if err := a.logViewer.AppendEntry(tuiLogPath(a.prdPath), entry); err != nil {
+				a.lastActivity = "Log write error: " + err.Error()
+			}
 		}
 	}
 
@@ -1217,8 +1222,12 @@ func (a App) handleLoopEvent(prdName string, event loop.Event) (tea.Model, tea.C
 			errMsg := ""
 			if event.Err != nil {
 				errMsg = event.Err.Error()
-				a.lastActivity = "Error: " + errMsg
+			} else if event.Text != "" {
+				errMsg = event.Text
+			} else {
+				errMsg = "Unknown error"
 			}
+			a.lastActivity = "Error: " + errMsg
 			// Show the modal on the 3rd consecutive failure (no story completed between)
 			if a.consecutiveErrors[prdName] >= 3 {
 				a.showErrorModal(errMsg)
@@ -2509,7 +2518,9 @@ func (a App) switchToPRD(name, prdPath string) (tea.Model, tea.Cmd) {
 	}
 
 	// Persist the current PRD's log to disk before clearing (must use OLD prdPath)
-	_ = a.logViewer.SaveEntries(tuiLogPath(a.prdPath))
+	if err := a.logViewer.SaveEntries(tuiLogPath(a.prdPath)); err != nil {
+		a.lastActivity = "Log save error: " + err.Error()
+	}
 
 	// Update app state
 	a.prd = newPRD
@@ -2541,8 +2552,12 @@ func (a App) switchToPRD(name, prdPath string) (tea.Model, tea.Cmd) {
 	// Restore any previously-saved log for the new PRD, then rewrite
 	// the file to match in-memory state (prevents duplicates from
 	// filtered events or append-after-load races).
-	_ = a.logViewer.LoadEntries(tuiLogPath(prdPath))
-	_ = a.logViewer.SaveEntries(tuiLogPath(prdPath))
+	if err := a.logViewer.LoadEntries(tuiLogPath(prdPath)); err != nil {
+		a.lastActivity = "Log load error: " + err.Error()
+	}
+	if err := a.logViewer.SaveEntries(tuiLogPath(prdPath)); err != nil {
+		a.lastActivity = "Log save error: " + err.Error()
+	}
 
 	a.storyTimings = nil
 	a.currentStoryID = ""

--- a/internal/tui/branch_warning.go
+++ b/internal/tui/branch_warning.go
@@ -272,7 +272,7 @@ func (b *BranchWarning) Render() string {
 	modal := modalStyle.Render(content.String())
 
 	// Center the modal on screen
-	return b.centerModal(modal)
+	return CenterModal(modal, b.width, b.height)
 }
 
 // renderHeader renders the dialog title and message.
@@ -366,45 +366,4 @@ func (b *BranchWarning) renderOptions(content *strings.Builder) {
 			content.WriteString("\n")
 		}
 	}
-}
-
-// centerModal centers the modal on the screen.
-func (b *BranchWarning) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	modalHeight := len(lines)
-	modalWidth := 0
-	for _, line := range lines {
-		if lipgloss.Width(line) > modalWidth {
-			modalWidth = lipgloss.Width(line)
-		}
-	}
-
-	// Calculate padding
-	topPadding := (b.height - modalHeight) / 2
-	leftPadding := (b.width - modalWidth) / 2
-
-	if topPadding < 0 {
-		topPadding = 0
-	}
-	if leftPadding < 0 {
-		leftPadding = 0
-	}
-
-	// Build centered content
-	var result strings.Builder
-
-	// Top padding
-	for i := 0; i < topPadding; i++ {
-		result.WriteString("\n")
-	}
-
-	// Modal lines with left padding
-	leftPad := strings.Repeat(" ", leftPadding)
-	for _, line := range lines {
-		result.WriteString(leftPad)
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return result.String()
 }

--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -263,7 +263,7 @@ func (c *CompletionScreen) Render() string {
 		return overlayModal(background, modal, c.width, c.height)
 	}
 
-	return centerModal(modal, c.width, c.height)
+	return CenterModal(modal, c.width, c.height)
 }
 
 // calculateModalHeight determines the dynamic modal height based on content.
@@ -575,41 +575,4 @@ func overlayModal(background, modal string, screenWidth, screenHeight int) strin
 	}
 
 	return strings.Join(bgLines[:screenHeight], "\n")
-}
-
-// centerModal centers a modal string on the screen.
-func centerModal(modal string, screenWidth, screenHeight int) string {
-	lines := strings.Split(modal, "\n")
-	modalHeight := len(lines)
-	modalWidth := 0
-	for _, line := range lines {
-		if lipgloss.Width(line) > modalWidth {
-			modalWidth = lipgloss.Width(line)
-		}
-	}
-
-	topPadding := (screenHeight - modalHeight) / 2
-	leftPadding := (screenWidth - modalWidth) / 2
-
-	if topPadding < 0 {
-		topPadding = 0
-	}
-	if leftPadding < 0 {
-		leftPadding = 0
-	}
-
-	var result strings.Builder
-
-	for i := 0; i < topPadding; i++ {
-		result.WriteString("\n")
-	}
-
-	leftPad := strings.Repeat(" ", leftPadding)
-	for _, line := range lines {
-		result.WriteString(leftPad)
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return result.String()
 }

--- a/internal/tui/completion_test.go
+++ b/internal/tui/completion_test.go
@@ -300,7 +300,7 @@ func TestCompletionScreen_PushErrorNonBlocking(t *testing.T) {
 
 func TestCenterModal(t *testing.T) {
 	modal := "test modal content"
-	result := centerModal(modal, 80, 40)
+	result := CenterModal(modal, 80, 40)
 
 	// Should have top padding and left padding
 	lines := strings.Split(result, "\n")

--- a/internal/tui/creation.go
+++ b/internal/tui/creation.go
@@ -406,10 +406,11 @@ func (c *PRDCreationChat) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			updated, modalCmd := c.questionModal.Update(msg)
 			c.questionModal = updated
 			if c.questionModal.IsDone() {
+				cancelled := c.questionModal.Cancelled()
 				answer := c.questionModal.BuildAnswer()
 				c.showingQuestionModal = false
 				c.questionModal = nil
-				if answer != "" {
+				if !cancelled && answer != "" {
 					// Inject the answer as a user message and send to Gemini
 					c.input.SetValue(answer)
 					return c, c.SendMessage()

--- a/internal/tui/creation.go
+++ b/internal/tui/creation.go
@@ -165,6 +165,10 @@ func (c *PRDCreationChat) SetSize(width, height int) {
 	c.input.SetWidth(vpWidth - 6)
 	c.input.SetHeight(3)
 
+	if c.questionModal != nil {
+		c.questionModal.SetSize(width, height)
+	}
+
 	c.renderViewport()
 }
 
@@ -560,7 +564,6 @@ func (c *PRDCreationChat) View() tea.View {
 
 	// Overlay the question modal if active
 	if c.showingQuestionModal && c.questionModal != nil {
-		c.questionModal.SetSize(c.width, c.height)
 		return tea.NewView(c.questionModal.Render())
 	}
 

--- a/internal/tui/creation.go
+++ b/internal/tui/creation.go
@@ -97,6 +97,10 @@ type PRDCreationChat struct {
 	// Track if Gemini has saved the PRD
 	prdSaved bool
 
+	// Question modal — shown when Gemini responds with structured clarifying questions
+	questionModal        *QuestionModal
+	showingQuestionModal bool
+
 	// Waiting animation state
 	spinnerFrame   int
 	robotFrame     int
@@ -362,7 +366,7 @@ func (c *PRDCreationChat) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				c.sessionID = msg.SessionID
 			}
 			c.messages = append(c.messages, Message{Role: RoleAssistant, Content: msg.Content})
-			
+
 			// Check if PRD was saved (heuristic: check if prd.md exists)
 			if strings.Contains(msg.Content, "prd.md") || strings.Contains(msg.Content, "saved") {
 				c.prdSaved = true
@@ -372,7 +376,16 @@ func (c *PRDCreationChat) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if strings.Contains(msg.Content, "/exit") || strings.Contains(msg.Content, "<melliza-complete/>") {
 				c.done = true
 			}
-			
+
+			// Detect structured clarifying questions and offer the modal
+			if !c.done && !c.showingQuestionModal {
+				if qs := ParseQuestions(msg.Content); len(qs) >= 2 {
+					c.questionModal = NewQuestionModal(qs)
+					c.questionModal.SetSize(c.width, c.height)
+					c.showingQuestionModal = true
+				}
+			}
+
 			c.renderViewport()
 			c.viewport.GotoBottom()
 		case "error":
@@ -384,6 +397,23 @@ func (c *PRDCreationChat) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.KeyPressMsg:
+		// Question modal intercepts all keys when active
+		if c.showingQuestionModal && c.questionModal != nil {
+			updated, modalCmd := c.questionModal.Update(msg)
+			c.questionModal = updated
+			if c.questionModal.IsDone() {
+				answer := c.questionModal.BuildAnswer()
+				c.showingQuestionModal = false
+				c.questionModal = nil
+				if answer != "" {
+					// Inject the answer as a user message and send to Gemini
+					c.input.SetValue(answer)
+					return c, c.SendMessage()
+				}
+			}
+			return c, modalCmd
+		}
+
 		// Viewport scrolling — always available
 		switch msg.String() {
 		case "pgup", "ctrl+u":
@@ -526,5 +556,13 @@ func (c *PRDCreationChat) View() tea.View {
 	}
 	b.WriteString(lipgloss.NewStyle().Foreground(MutedColor).Padding(0, 1).Render(shortcuts))
 
-	return tea.NewView(lipgloss.NewStyle().Padding(1, 2).Render(b.String()))
+	base := lipgloss.NewStyle().Padding(1, 2).Render(b.String())
+
+	// Overlay the question modal if active
+	if c.showingQuestionModal && c.questionModal != nil {
+		c.questionModal.SetSize(c.width, c.height)
+		return tea.NewView(c.questionModal.Render())
+	}
+
+	return tea.NewView(base)
 }

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -555,7 +555,11 @@ func (a *App) renderDetailsPanel(width, height int) string {
 	}
 	a.detailsVP.SetWidth(innerW)
 	a.detailsVP.SetHeight(innerH)
-	a.detailsVP.SetContent(content.String())
+	rendered := content.String()
+	if rendered != a.detailsVPContent {
+		a.detailsVPContent = rendered
+		a.detailsVP.SetContent(rendered)
+	}
 
 	return panelStyle.Width(width).Height(height).Render(a.detailsVP.View())
 }

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -547,52 +547,17 @@ func (a *App) renderDetailsPanel(width, height int) string {
 		}
 	}
 
-	// Apply scrolling: inner height is panel height minus border frame
+	// Feed content into the viewport (size: inner area minus panel border)
+	innerW := width - 4 // left+right border+padding
 	innerH := height - 2
 	if innerH < 1 {
 		innerH = 1
 	}
-	allLines := strings.Split(content.String(), "\n")
-	totalLines := len(allLines)
+	a.detailsVP.SetWidth(innerW)
+	a.detailsVP.SetHeight(innerH)
+	a.detailsVP.SetContent(content.String())
 
-	// Clamp scroll offset
-	maxScroll := totalLines - innerH
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
-	if a.detailsScrollOffset > maxScroll {
-		a.detailsScrollOffset = maxScroll
-	}
-	if a.detailsScrollOffset < 0 {
-		a.detailsScrollOffset = 0
-	}
-
-	// Slice visible lines
-	start := a.detailsScrollOffset
-	end := start + innerH
-	if end > totalLines {
-		end = totalLines
-	}
-	visible := strings.Join(allLines[start:end], "\n")
-
-	// Show scroll indicator if content overflows
-	if totalLines > innerH {
-		pct := 0
-		if maxScroll > 0 {
-			pct = a.detailsScrollOffset * 100 / maxScroll
-		}
-		indicator := lipgloss.NewStyle().Foreground(MutedColor).Render(fmt.Sprintf(" ↕ %d%%", pct))
-		// Prepend scroll indicator to first visible line
-		visible = indicator + "\n" + visible
-		// Trim to innerH lines
-		vlines := strings.Split(visible, "\n")
-		if len(vlines) > innerH {
-			vlines = vlines[:innerH]
-		}
-		visible = strings.Join(vlines, "\n")
-	}
-
-	return panelStyle.Width(width).Height(height).Render(visible)
+	return panelStyle.Width(width).Height(height).Render(a.detailsVP.View())
 }
 
 // renderErrorPanel renders the error details panel when in error state.

--- a/internal/tui/error_modal.go
+++ b/internal/tui/error_modal.go
@@ -1,0 +1,280 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// ErrorModalChoice represents what the user selected in the error modal.
+type ErrorModalChoice int
+
+const (
+	ErrorChoiceNone      ErrorModalChoice = iota
+	ErrorChoiceSaveQuit                   // Save progress and quit Melliza
+	ErrorChoiceStopLoop                   // Stop just this loop, stay in TUI
+	ErrorChoiceContinue                   // Dismiss and keep going
+)
+
+// errorItem implements list.DefaultItem for the fancy list in the error modal.
+type errorItem struct {
+	title       string
+	description string
+	choice      ErrorModalChoice
+	recommended bool
+}
+
+func (i errorItem) Title() string {
+	if i.recommended {
+		return i.title + " (Recommended)"
+	}
+	return i.title
+}
+func (i errorItem) Description() string { return i.description }
+func (i errorItem) FilterValue() string { return i.title }
+
+// errorModalKeyMap holds keys specific to the error modal list.
+type errorModalKeyMap struct {
+	choose key.Binding
+}
+
+func (k errorModalKeyMap) ShortHelp() []key.Binding  { return []key.Binding{k.choose} }
+func (k errorModalKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{{k.choose}} }
+
+func newErrorModalKeyMap() errorModalKeyMap {
+	return errorModalKeyMap{
+		choose: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "select"),
+		),
+	}
+}
+
+// ErrorModal is a centered overlay that appears after repeated failures without
+// progress. It uses a list-fancy style delegate so each option has a title and
+// description row with visual highlighting.
+type ErrorModal struct {
+	list    list.Model
+	keys    errorModalKeyMap
+	errText string // trimmed error message to display
+	width   int
+	height  int
+	done    bool
+	choice  ErrorModalChoice
+}
+
+// NewErrorModal creates an ErrorModal. Width/height are set later via SetSize.
+func NewErrorModal() *ErrorModal {
+	keys := newErrorModalKeyMap()
+
+	items := []list.Item{
+		errorItem{
+			title:       "Save and quit",
+			description: "Stop the loop, save your progress, and exit Melliza",
+			choice:      ErrorChoiceSaveQuit,
+			recommended: true,
+		},
+		errorItem{
+			title:       "Stop loop",
+			description: "Keep Melliza open but stop running this PRD",
+			choice:      ErrorChoiceStopLoop,
+		},
+		errorItem{
+			title:       "Continue anyway",
+			description: "Dismiss this message and let the loop keep trying",
+			choice:      ErrorChoiceContinue,
+		},
+	}
+
+	delegate := newErrorModalDelegate(keys)
+	l := list.New(items, delegate, 0, 0)
+	l.SetShowTitle(false)
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+	l.SetShowHelp(false)
+	l.SetShowPagination(false)
+	l.KeyMap.Quit = key.NewBinding() // disable q-to-quit inside the modal
+
+	return &ErrorModal{
+		list: l,
+		keys: keys,
+	}
+}
+
+// newErrorModalDelegate returns a styled list delegate for the error modal.
+func newErrorModalDelegate(keys errorModalKeyMap) list.DefaultDelegate {
+	d := list.NewDefaultDelegate()
+
+	// Style: selected item uses error red for title
+	d.Styles.SelectedTitle = d.Styles.SelectedTitle.
+		Foreground(ErrorColor).
+		BorderLeftForeground(ErrorColor)
+	d.Styles.SelectedDesc = d.Styles.SelectedDesc.
+		Foreground(lipgloss.Color("#FF8C87")).
+		BorderLeftForeground(ErrorColor)
+
+	d.UpdateFunc = func(msg tea.Msg, m *list.Model) tea.Cmd {
+		// enter is handled in ErrorModal.Update; nothing special here
+		return nil
+	}
+
+	d.ShortHelpFunc = func() []key.Binding { return []key.Binding{keys.choose} }
+	d.FullHelpFunc = func() [][]key.Binding { return [][]key.Binding{{keys.choose}} }
+
+	return d
+}
+
+// SetSize updates the modal and inner list dimensions.
+func (m *ErrorModal) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	// Inner list width = modal content area (modal is ~60 chars wide, minus padding/border)
+	modalWidth := min(64, width-10)
+	if modalWidth < 44 {
+		modalWidth = 44
+	}
+	// 3 items × 2 lines each + spacing
+	listHeight := 3 * 3
+	m.list.SetSize(modalWidth-4, listHeight)
+}
+
+// SetError stores the error text shown inside the modal header.
+func (m *ErrorModal) SetError(errText string) {
+	// Trim to keep the modal compact
+	if len(errText) > 160 {
+		errText = errText[:157] + "..."
+	}
+	m.errText = errText
+	m.done = false
+	m.choice = ErrorChoiceNone
+	// Reset selection to first item (Save and quit)
+	m.list.Select(0)
+}
+
+// Reset resets modal state so it can be reused for a new error.
+func (m *ErrorModal) Reset() {
+	m.done = false
+	m.choice = ErrorChoiceNone
+	m.list.Select(0)
+}
+
+// IsDone returns true once the user has confirmed a choice.
+func (m *ErrorModal) IsDone() bool { return m.done }
+
+// Choice returns the selected option (valid after IsDone() == true).
+func (m *ErrorModal) Choice() ErrorModalChoice { return m.choice }
+
+// Update handles key input for the error modal.
+func (m *ErrorModal) Update(msg tea.Msg) (*ErrorModal, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.keys.choose):
+			if sel, ok := m.list.SelectedItem().(errorItem); ok {
+				m.choice = sel.choice
+				m.done = true
+			}
+			return m, nil
+		case msg.String() == "esc":
+			// Esc = dismiss (same as Continue)
+			m.choice = ErrorChoiceContinue
+			m.done = true
+			return m, nil
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// Render draws the centered error modal overlay.
+func (m *ErrorModal) Render() string {
+	modalWidth := min(64, m.width-10)
+	if modalWidth < 44 {
+		modalWidth = 44
+	}
+	innerWidth := modalWidth - 4 // subtract border + padding
+
+	var b strings.Builder
+
+	// ── Title ──
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ErrorColor)
+	b.WriteString(titleStyle.Render("Oops!"))
+	b.WriteString("\n")
+	b.WriteString(DividerStyle.Render(strings.Repeat("─", innerWidth)))
+	b.WriteString("\n\n")
+
+	// ── Sub-heading ──
+	subStyle := lipgloss.NewStyle().Foreground(WarningColor).Bold(true)
+	b.WriteString(subStyle.Render("Looks like we hit a snag..."))
+	b.WriteString("\n\n")
+
+	// ── Error message ──
+	if m.errText != "" {
+		errStyle := lipgloss.NewStyle().
+			Foreground(TextMutedColor).
+			Width(innerWidth)
+		// Word-wrap manually so long lines don't overflow
+		b.WriteString(errStyle.Render(m.errText))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString(DividerStyle.Render(strings.Repeat("─", innerWidth)))
+	b.WriteString("\n")
+
+	// ── Fancy list of options ──
+	b.WriteString(m.list.View())
+	b.WriteString("\n")
+
+	// ── Footer hint ──
+	b.WriteString(DividerStyle.Render(strings.Repeat("─", innerWidth)))
+	b.WriteString("\n")
+	footerStyle := lipgloss.NewStyle().Foreground(MutedColor)
+	b.WriteString(footerStyle.Render("↑/↓ Navigate   Enter Select   Esc Dismiss"))
+
+	// ── Modal box ──
+	modalStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ErrorColor).
+		Padding(1, 2).
+		Width(modalWidth)
+
+	modal := modalStyle.Render(b.String())
+	return m.centerModal(modal)
+}
+
+func (m *ErrorModal) centerModal(modal string) string {
+	lines := strings.Split(modal, "\n")
+	mh := len(lines)
+	mw := 0
+	for _, l := range lines {
+		if w := lipgloss.Width(l); w > mw {
+			mw = w
+		}
+	}
+
+	top := (m.height - mh) / 2
+	left := (m.width - mw) / 2
+	if top < 0 {
+		top = 0
+	}
+	if left < 0 {
+		left = 0
+	}
+
+	var out strings.Builder
+	pad := strings.Repeat(" ", left)
+	for i := 0; i < top; i++ {
+		out.WriteString("\n")
+	}
+	for _, line := range lines {
+		out.WriteString(pad)
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+	return out.String()
+}

--- a/internal/tui/error_modal.go
+++ b/internal/tui/error_modal.go
@@ -143,9 +143,10 @@ func (m *ErrorModal) SetSize(width, height int) {
 
 // SetError stores the error text shown inside the modal header.
 func (m *ErrorModal) SetError(errText string) {
-	// Trim to keep the modal compact
-	if len(errText) > 160 {
-		errText = errText[:157] + "..."
+	// Trim to keep the modal compact (rune-safe to avoid splitting multi-byte UTF-8)
+	runes := []rune(errText)
+	if len(runes) > 160 {
+		errText = string(runes[:157]) + "..."
 	}
 	m.errText = errText
 	m.done = false

--- a/internal/tui/error_modal.go
+++ b/internal/tui/error_modal.go
@@ -244,37 +244,5 @@ func (m *ErrorModal) Render() string {
 		Width(modalWidth)
 
 	modal := modalStyle.Render(b.String())
-	return m.centerModal(modal)
-}
-
-func (m *ErrorModal) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	mh := len(lines)
-	mw := 0
-	for _, l := range lines {
-		if w := lipgloss.Width(l); w > mw {
-			mw = w
-		}
-	}
-
-	top := (m.height - mh) / 2
-	left := (m.width - mw) / 2
-	if top < 0 {
-		top = 0
-	}
-	if left < 0 {
-		left = 0
-	}
-
-	var out strings.Builder
-	pad := strings.Repeat(" ", left)
-	for i := 0; i < top; i++ {
-		out.WriteString("\n")
-	}
-	for _, line := range lines {
-		out.WriteString(pad)
-		out.WriteString(line)
-		out.WriteString("\n")
-	}
-	return out.String()
+	return CenterModal(modal, m.width, m.height)
 }

--- a/internal/tui/first_time_setup.go
+++ b/internal/tui/first_time_setup.go
@@ -471,7 +471,7 @@ func (f FirstTimeSetup) renderGitignoreStep() string {
 
 	modal := modalStyle.Render(content.String())
 
-	return f.centerModal(modal)
+	return CenterModal(modal, f.width, f.height)
 }
 
 func (f FirstTimeSetup) renderPRDNameStep() string {
@@ -549,7 +549,7 @@ func (f FirstTimeSetup) renderPRDNameStep() string {
 
 	modal := modalStyle.Render(content.String())
 
-	return f.centerModal(modal)
+	return CenterModal(modal, f.width, f.height)
 }
 
 func (f FirstTimeSetup) renderPostCompletionStep() string {
@@ -655,7 +655,7 @@ func (f FirstTimeSetup) renderPostCompletionStep() string {
 
 	modal := modalStyle.Render(content.String())
 
-	return f.centerModal(modal)
+	return CenterModal(modal, f.width, f.height)
 }
 
 func (f FirstTimeSetup) renderGHErrorStep() string {
@@ -720,43 +720,7 @@ func (f FirstTimeSetup) renderGHErrorStep() string {
 
 	modal := modalStyle.Render(content.String())
 
-	return f.centerModal(modal)
-}
-
-func (f FirstTimeSetup) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	modalHeight := len(lines)
-	modalWidth := 0
-	for _, line := range lines {
-		if lipgloss.Width(line) > modalWidth {
-			modalWidth = lipgloss.Width(line)
-		}
-	}
-
-	topPadding := (f.height - modalHeight) / 2
-	leftPadding := (f.width - modalWidth) / 2
-
-	if topPadding < 0 {
-		topPadding = 0
-	}
-	if leftPadding < 0 {
-		leftPadding = 0
-	}
-
-	var result strings.Builder
-
-	for i := 0; i < topPadding; i++ {
-		result.WriteString("\n")
-	}
-
-	leftPad := strings.Repeat(" ", leftPadding)
-	for _, line := range lines {
-		result.WriteString(leftPad)
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return result.String()
+	return CenterModal(modal, f.width, f.height)
 }
 
 // GetResult returns the setup result.

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -212,7 +212,7 @@ func (h *HelpOverlay) Render() string {
 	modal := modalStyle.Render(content.String())
 
 	// Center the modal on screen
-	return h.centerModal(modal)
+	return CenterModal(modal, h.width, h.height)
 }
 
 // renderCategory renders a single category of shortcuts.
@@ -249,45 +249,4 @@ func (h *HelpOverlay) renderCategory(w *strings.Builder, cat ShortcutCategory, w
 		w.WriteString("\n")
 	}
 	w.WriteString("\n")
-}
-
-// centerModal centers the modal on the screen.
-func (h *HelpOverlay) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	modalHeight := len(lines)
-	modalWidth := 0
-	for _, line := range lines {
-		if lipgloss.Width(line) > modalWidth {
-			modalWidth = lipgloss.Width(line)
-		}
-	}
-
-	// Calculate padding
-	topPadding := (h.height - modalHeight) / 2
-	leftPadding := (h.width - modalWidth) / 2
-
-	if topPadding < 0 {
-		topPadding = 0
-	}
-	if leftPadding < 0 {
-		leftPadding = 0
-	}
-
-	// Build centered content
-	var result strings.Builder
-
-	// Top padding
-	for i := 0; i < topPadding; i++ {
-		result.WriteString("\n")
-	}
-
-	// Modal lines with left padding
-	leftPad := strings.Repeat(" ", leftPadding)
-	for _, line := range lines {
-		result.WriteString(leftPad)
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return result.String()
 }

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// CenterModal centers a rendered modal string on the screen.
+func CenterModal(modal string, screenWidth, screenHeight int) string {
+	lines := strings.Split(modal, "\n")
+	modalHeight := len(lines)
+	modalWidth := 0
+	for _, line := range lines {
+		if w := lipgloss.Width(line); w > modalWidth {
+			modalWidth = w
+		}
+	}
+
+	topPadding := (screenHeight - modalHeight) / 2
+	leftPadding := (screenWidth - modalWidth) / 2
+
+	if topPadding < 0 {
+		topPadding = 0
+	}
+	if leftPadding < 0 {
+		leftPadding = 0
+	}
+
+	var result strings.Builder
+
+	for i := 0; i < topPadding; i++ {
+		result.WriteString("\n")
+	}
+
+	leftPad := strings.Repeat(" ", leftPadding)
+	for _, line := range lines {
+		result.WriteString(leftPad)
+		result.WriteString(line)
+		result.WriteString("\n")
+	}
+	return result.String()
+}

--- a/internal/tui/helpers_test.go
+++ b/internal/tui/helpers_test.go
@@ -1,0 +1,82 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCenterModal_BasicCentering(t *testing.T) {
+	modal := "hello"
+	result := CenterModal(modal, 80, 40)
+
+	lines := strings.Split(result, "\n")
+	// Should have top padding (empty lines before content)
+	hasTopPadding := false
+	for _, line := range lines {
+		if line == "" {
+			hasTopPadding = true
+			break
+		}
+	}
+	if !hasTopPadding {
+		t.Error("expected top padding")
+	}
+
+	// Find the content line and verify left padding
+	for _, line := range lines {
+		if strings.Contains(line, "hello") {
+			leftPad := len(line) - len(strings.TrimLeft(line, " "))
+			if leftPad == 0 {
+				t.Error("expected left padding")
+			}
+			break
+		}
+	}
+}
+
+func TestCenterModal_SmallScreen(t *testing.T) {
+	modal := strings.Repeat("x", 100)
+	result := CenterModal(modal, 50, 10)
+
+	// Should not panic and should clamp padding to 0
+	if !strings.Contains(result, strings.Repeat("x", 100)) {
+		t.Error("expected modal content to be preserved")
+	}
+}
+
+func TestCenterModal_ExactFit(t *testing.T) {
+	modal := "test"
+	result := CenterModal(modal, 4, 1)
+
+	// Width matches exactly, so left padding should be 0
+	lines := strings.Split(result, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "test") {
+			leftPad := len(line) - len(strings.TrimLeft(line, " "))
+			if leftPad != 0 {
+				t.Errorf("expected 0 left padding for exact fit, got %d", leftPad)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("modal content not found in output")
+	}
+}
+
+func TestCenterModal_MultilineModal(t *testing.T) {
+	modal := "line1\nline2\nline3"
+	result := CenterModal(modal, 80, 40)
+
+	if !strings.Contains(result, "line1") {
+		t.Error("expected line1 in output")
+	}
+	if !strings.Contains(result, "line2") {
+		t.Error("expected line2 in output")
+	}
+	if !strings.Contains(result, "line3") {
+		t.Error("expected line3 in output")
+	}
+}

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -97,7 +97,7 @@ func (l *LogViewer) AddEvent(event loop.Event) {
 		loop.EventToolStart, loop.EventToolResult,
 		loop.EventStoryStarted, loop.EventStoryCompleted,
 		loop.EventComplete, loop.EventError, loop.EventRetrying,
-		loop.EventWatchdogTimeout:
+		loop.EventWatchdogTimeout, loop.EventRateLimit:
 		// Always show these semantic events
 	case loop.EventStderr:
 		// Show error-bearing stderr lines even in non-verbose mode
@@ -386,7 +386,7 @@ func (l *LogViewer) LoadEntries(path string) error {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 	for scanner.Scan() {
 		var j logEntryJSON
 		if err := json.Unmarshal(scanner.Bytes(), &j); err != nil {

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -314,6 +314,14 @@ func (l *LogViewer) IsAutoScrolling() bool {
 	return l.autoScroll
 }
 
+// LastEntry returns the last log entry, or false if empty.
+func (l *LogViewer) LastEntry() (LogEntry, bool) {
+	if len(l.entries) == 0 {
+		return LogEntry{}, false
+	}
+	return l.entries[len(l.entries)-1], true
+}
+
 // Clear clears all log entries.
 func (l *LogViewer) Clear() {
 	l.entries = make([]LogEntry, 0)

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -1,8 +1,11 @@
 package tui
 
 import (
+	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -320,6 +323,100 @@ func (l *LogViewer) Clear() {
 	l.contentDirty = false
 	l.vp.SetContent("")
 	l.vp.GotoTop()
+}
+
+// logEntryJSON is the on-disk serialisation format for a LogEntry.
+// Only raw fields are persisted; derived/cached fields are recomputed on load.
+type logEntryJSON struct {
+	Type      loop.EventType         `json:"type"`
+	Iteration int                    `json:"iteration"`
+	Text      string                 `json:"text,omitempty"`
+	Tool      string                 `json:"tool,omitempty"`
+	ToolInput map[string]interface{} `json:"toolInput,omitempty"`
+	StoryID   string                 `json:"storyID,omitempty"`
+	FilePath  string                 `json:"filePath,omitempty"`
+}
+
+// SaveEntries writes all current log entries to a JSONL file at path.
+// Existing file contents are replaced.
+func (l *LogViewer) SaveEntries(path string) error {
+	if len(l.entries) == 0 {
+		return nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, e := range l.entries {
+		if err := enc.Encode(logEntryJSON{
+			Type:      e.Type,
+			Iteration: e.Iteration,
+			Text:      e.Text,
+			Tool:      e.Tool,
+			ToolInput: e.ToolInput,
+			StoryID:   e.StoryID,
+			FilePath:  e.FilePath,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LoadEntries reads JSONL log entries from path and replays them into the viewer.
+// Call Clear() first if you want a clean slate.
+func (l *LogViewer) LoadEntries(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // no prior log; nothing to do
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	for scanner.Scan() {
+		var j logEntryJSON
+		if err := json.Unmarshal(scanner.Bytes(), &j); err != nil {
+			continue // skip malformed lines
+		}
+		l.AddEvent(loop.Event{
+			Type:      j.Type,
+			Iteration: j.Iteration,
+			Text:      j.Text,
+			Tool:      j.Tool,
+			ToolInput: j.ToolInput,
+			StoryID:   j.StoryID,
+		})
+		// Restore the file path for the last-read tracking used by syntax highlighting
+		if j.FilePath != "" && len(l.entries) > 0 {
+			l.entries[len(l.entries)-1].FilePath = j.FilePath
+		}
+	}
+	return scanner.Err()
+}
+
+// AppendEntry appends a single log entry to a JSONL file at path (append-only).
+// This is called after each new event so the file stays up to date without a full rewrite.
+func (l *LogViewer) AppendEntry(path string, e LogEntry) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return json.NewEncoder(f).Encode(logEntryJSON{
+		Type:      e.Type,
+		Iteration: e.Iteration,
+		Text:      e.Text,
+		Tool:      e.Tool,
+		ToolInput: e.ToolInput,
+		StoryID:   e.StoryID,
+		FilePath:  e.FilePath,
+	})
 }
 
 // flushContent syncs the content buffer to the viewport if dirty.

--- a/internal/tui/log_test.go
+++ b/internal/tui/log_test.go
@@ -1,6 +1,12 @@
 package tui
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lvcoi/melliza/internal/loop"
+)
 
 func TestGetToolIcon(t *testing.T) {
 	tests := []struct {
@@ -162,6 +168,122 @@ func TestLogViewer_IsAutoScrolling(t *testing.T) {
 	// autoScroll should still be true if at top (nothing to scroll up from)
 	if !lv.IsAutoScrolling() {
 		t.Error("Expected IsAutoScrolling to remain true when at top")
+	}
+}
+
+// ── Fix 1: Duplicate-on-reload log bug ───────────────────────────────────────
+
+func TestLogViewer_SaveLoadNoDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "test.jsonl")
+
+	lv := NewLogViewer()
+	lv.SetSize(80, 40)
+
+	// Write 3 entries via AddEvent + AppendEntry (simulates live events)
+	for i, text := range []string{"event1", "event2", "event3"} {
+		evt := loop.Event{Type: loop.EventAssistantText, Iteration: i + 1, Text: text}
+		lv.AddEvent(evt)
+		if len(lv.entries) > 0 {
+			_ = lv.AppendEntry(logPath, lv.entries[len(lv.entries)-1])
+		}
+	}
+	if len(lv.entries) != 3 {
+		t.Fatalf("expected 3 entries after add, got %d", len(lv.entries))
+	}
+
+	// Simulate switch: save → clear → load
+	_ = lv.SaveEntries(logPath)
+	lv.Clear()
+	_ = lv.LoadEntries(logPath)
+
+	if len(lv.entries) != 3 {
+		t.Fatalf("expected 3 entries after load, got %d", len(lv.entries))
+	}
+
+	// Rewrite file to match in-memory state (the fix)
+	_ = lv.SaveEntries(logPath)
+
+	// Add a new live event + append
+	newEvt := loop.Event{Type: loop.EventAssistantText, Iteration: 4, Text: "event4"}
+	lv.AddEvent(newEvt)
+	if len(lv.entries) > 0 {
+		_ = lv.AppendEntry(logPath, lv.entries[len(lv.entries)-1])
+	}
+
+	// Simulate another switch cycle: save → clear → load
+	_ = lv.SaveEntries(logPath)
+	lv.Clear()
+	_ = lv.LoadEntries(logPath)
+
+	if len(lv.entries) != 4 {
+		t.Errorf("expected 4 entries after second reload, got %d", len(lv.entries))
+	}
+
+	// Verify no duplicates by checking entry text
+	texts := make(map[string]int)
+	for _, e := range lv.entries {
+		texts[e.Text]++
+	}
+	for text, count := range texts {
+		if count > 1 {
+			t.Errorf("duplicate entry %q appeared %d times", text, count)
+		}
+	}
+}
+
+func TestLogViewer_LoadEntries_NonExistentFile(t *testing.T) {
+	lv := NewLogViewer()
+	err := lv.LoadEntries("/nonexistent/path/log.jsonl")
+	if err != nil {
+		t.Errorf("expected nil error for nonexistent file, got %v", err)
+	}
+	if len(lv.entries) != 0 {
+		t.Error("expected 0 entries for nonexistent file")
+	}
+}
+
+func TestLogViewer_SaveEntries_EmptyIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "test.jsonl")
+
+	lv := NewLogViewer()
+	err := lv.SaveEntries(logPath)
+	if err != nil {
+		t.Errorf("expected nil error for empty save, got %v", err)
+	}
+	// File should NOT be created for empty entries
+	if _, err := os.Stat(logPath); err == nil {
+		t.Error("expected no file to be created for empty save")
+	}
+}
+
+// ── Fix 2: LastEntry accessor ────────────────────────────────────────────────
+
+func TestLogViewer_LastEntry_Empty(t *testing.T) {
+	lv := NewLogViewer()
+	_, ok := lv.LastEntry()
+	if ok {
+		t.Error("expected LastEntry() to return false for empty log")
+	}
+}
+
+func TestLogViewer_LastEntry_WithEntries(t *testing.T) {
+	lv := NewLogViewer()
+	lv.SetSize(80, 40)
+
+	lv.AddEvent(loop.Event{Type: loop.EventAssistantText, Iteration: 1, Text: "first"})
+	lv.AddEvent(loop.Event{Type: loop.EventAssistantText, Iteration: 2, Text: "second"})
+
+	entry, ok := lv.LastEntry()
+	if !ok {
+		t.Fatal("expected LastEntry() to return true")
+	}
+	if entry.Text != "second" {
+		t.Errorf("expected last entry text 'second', got %q", entry.Text)
+	}
+	if entry.Iteration != 2 {
+		t.Errorf("expected last entry iteration 2, got %d", entry.Iteration)
 	}
 }
 

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -624,7 +624,7 @@ func (p *PRDPicker) Render() string {
 	modal := modalStyle.Render(content.String())
 
 	// Center the modal on screen
-	return p.centerModal(modal)
+	return CenterModal(modal, p.width, p.height)
 }
 
 // renderEntry renders a single PRD entry line.
@@ -972,7 +972,7 @@ func (p *PRDPicker) renderMergeResult(modalWidth, modalHeight int) string {
 		Height(modalHeight)
 
 	modal := modalStyle.Render(content.String())
-	return p.centerModal(modal)
+	return CenterModal(modal, p.width, p.height)
 }
 
 // renderCleanConfirmation renders the clean confirmation dialog.
@@ -1048,7 +1048,7 @@ func (p *PRDPicker) renderCleanConfirmation(modalWidth, modalHeight int) string 
 		Height(modalHeight)
 
 	modal := modalStyle.Render(content.String())
-	return p.centerModal(modal)
+	return CenterModal(modal, p.width, p.height)
 }
 
 // renderCleanResult renders the clean result dialog.
@@ -1100,7 +1100,7 @@ func (p *PRDPicker) renderCleanResult(modalWidth, modalHeight int) string {
 		Height(modalHeight)
 
 	modal := modalStyle.Render(content.String())
-	return p.centerModal(modal)
+	return CenterModal(modal, p.width, p.height)
 }
 
 // renderDeleteConfirmation renders the delete confirmation dialog.
@@ -1168,7 +1168,7 @@ func (p *PRDPicker) renderDeleteConfirmation(modalWidth, modalHeight int) string
 		Height(modalHeight)
 
 	modal := modalStyle.Render(content.String())
-	return p.centerModal(modal)
+	return CenterModal(modal, p.width, p.height)
 }
 
 // renderDeleteResult renders the delete result dialog.
@@ -1220,46 +1220,5 @@ func (p *PRDPicker) renderDeleteResult(modalWidth, modalHeight int) string {
 		Height(modalHeight)
 
 	modal := modalStyle.Render(content.String())
-	return p.centerModal(modal)
-}
-
-// centerModal centers the modal on the screen.
-func (p *PRDPicker) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	modalHeight := len(lines)
-	modalWidth := 0
-	for _, line := range lines {
-		if lipgloss.Width(line) > modalWidth {
-			modalWidth = lipgloss.Width(line)
-		}
-	}
-
-	// Calculate padding
-	topPadding := (p.height - modalHeight) / 2
-	leftPadding := (p.width - modalWidth) / 2
-
-	if topPadding < 0 {
-		topPadding = 0
-	}
-	if leftPadding < 0 {
-		leftPadding = 0
-	}
-
-	// Build centered content
-	var result strings.Builder
-
-	// Top padding
-	for i := 0; i < topPadding; i++ {
-		result.WriteString("\n")
-	}
-
-	// Modal lines with left padding
-	leftPad := strings.Repeat(" ", leftPadding)
-	for _, line := range lines {
-		result.WriteString(leftPad)
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return result.String()
+	return CenterModal(modal, p.width, p.height)
 }

--- a/internal/tui/question_modal.go
+++ b/internal/tui/question_modal.go
@@ -41,7 +41,8 @@ var reOption = regexp.MustCompile(`(?m)^\s*[-*]?\s*([A-Ea-e])[.)]\s+(.+)`)
 
 // ParseQuestions attempts to extract structured Q&A from Gemini's markdown text.
 // Returns nil if fewer than 2 questions are found (don't trigger the modal for
-// regular prose).
+// regular prose). Requires at least one question mark in each question's text
+// to avoid false positives on numbered implementation steps.
 func ParseQuestions(text string) []ParsedQuestion {
 	var questions []ParsedQuestion
 
@@ -59,9 +60,16 @@ func ParseQuestions(text string) []ParsedQuestion {
 		}
 		block := text[loc[0]:end]
 
-		// Extract question text (first line of block, stripped of numbering)
-		firstLine := strings.TrimSpace(strings.SplitN(block, "\n", 2)[0])
+		// Extract question text (first line of block, stripped of numbering).
+		// TrimSpace the block first because the regex match may include a leading \n.
+		firstLine := strings.TrimSpace(strings.SplitN(strings.TrimSpace(block), "\n", 2)[0])
 		firstLine = regexp.MustCompile(`^\d+[.)]\s*`).ReplaceAllString(firstLine, "")
+
+		// Require the question text to contain a question mark — this filters
+		// out numbered implementation steps with lettered sub-items.
+		if !strings.Contains(firstLine, "?") {
+			continue
+		}
 
 		// Extract lettered options from the block
 		optMatches := reOption.FindAllStringSubmatch(block, -1)
@@ -432,35 +440,5 @@ func (m *QuestionModal) Render() string {
 		Width(modalWidth)
 
 	modal := modalStyle.Render(b.String())
-	return m.centerModal(modal)
-}
-
-func (m *QuestionModal) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	mh := len(lines)
-	mw := 0
-	for _, l := range lines {
-		if w := lipgloss.Width(l); w > mw {
-			mw = w
-		}
-	}
-	top := (m.height - mh) / 2
-	left := (m.width - mw) / 2
-	if top < 0 {
-		top = 0
-	}
-	if left < 0 {
-		left = 0
-	}
-	var out strings.Builder
-	pad := strings.Repeat(" ", left)
-	for i := 0; i < top; i++ {
-		out.WriteString("\n")
-	}
-	for _, line := range lines {
-		out.WriteString(pad)
-		out.WriteString(line)
-		out.WriteString("\n")
-	}
-	return out.String()
+	return CenterModal(modal, m.width, m.height)
 }

--- a/internal/tui/question_modal.go
+++ b/internal/tui/question_modal.go
@@ -239,11 +239,12 @@ func (m *QuestionModal) listHeight() int {
 	return n * 2
 }
 
-// SetSize updates modal dimensions and rebuilds the list.
+// SetSize updates modal dimensions and resizes the list without rebuilding it,
+// so that the cursor position is preserved across renders.
 func (m *QuestionModal) SetSize(width, height int) {
 	m.width = width
 	m.height = height
-	m.list = m.buildList(m.currentQ)
+	m.list.SetSize(m.listWidth(), m.listHeight())
 	for i := range m.otherInputs {
 		m.otherInputs[i].SetWidth(m.listWidth() - 2)
 	}

--- a/internal/tui/question_modal.go
+++ b/internal/tui/question_modal.go
@@ -1,0 +1,466 @@
+package tui
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/list"
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// ─── Domain types ────────────────────────────────────────────────────────────
+
+// ParsedQuestion holds one clarifying question and its lettered options.
+type ParsedQuestion struct {
+	Text    string
+	Options []string // e.g. ["A. Improve onboarding", "B. Increase retention"]
+}
+
+// questionOption implements list.DefaultItem for the fancy list inside the modal.
+type questionOption struct {
+	letter string // "A", "B", "C", …
+	text   string
+	isOther bool
+}
+
+func (o questionOption) Title() string       { return o.letter + ". " + o.text }
+func (o questionOption) Description() string { return "" }
+func (o questionOption) FilterValue() string { return o.letter }
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+// numberedQ matches lines like "1." / "1)" at the start of a line.
+var reQuestion = regexp.MustCompile(`(?m)^\s*\d+[.)]\s+(.+)`)
+
+// letteredOpt matches lines like "A." / "a)" / "- A." at the start of a line.
+var reOption = regexp.MustCompile(`(?m)^\s*[-*]?\s*([A-Ea-e])[.)]\s+(.+)`)
+
+// ParseQuestions attempts to extract structured Q&A from Gemini's markdown text.
+// Returns nil if fewer than 2 questions are found (don't trigger the modal for
+// regular prose).
+func ParseQuestions(text string) []ParsedQuestion {
+	var questions []ParsedQuestion
+
+	// Split on numbered question markers — each chunk is one question block.
+	chunks := reQuestion.FindAllStringIndex(text, -1)
+	if len(chunks) < 2 {
+		return nil
+	}
+
+	// Build question blocks
+	for i, loc := range chunks {
+		end := len(text)
+		if i+1 < len(chunks) {
+			end = chunks[i+1][0]
+		}
+		block := text[loc[0]:end]
+
+		// Extract question text (first line of block, stripped of numbering)
+		firstLine := strings.TrimSpace(strings.SplitN(block, "\n", 2)[0])
+		firstLine = regexp.MustCompile(`^\d+[.)]\s*`).ReplaceAllString(firstLine, "")
+
+		// Extract lettered options from the block
+		optMatches := reOption.FindAllStringSubmatch(block, -1)
+		var opts []string
+		seenLetters := map[string]bool{}
+		for _, m := range optMatches {
+			letter := strings.ToUpper(m[1])
+			if seenLetters[letter] {
+				continue
+			}
+			seenLetters[letter] = true
+			opts = append(opts, letter+". "+strings.TrimSpace(m[2]))
+		}
+
+		if len(opts) >= 2 || len(questions) > 0 {
+			// Allow a question with no options (free text) if we already have
+			// some structured questions.
+			questions = append(questions, ParsedQuestion{
+				Text:    firstLine,
+				Options: opts,
+			})
+		}
+	}
+
+	if len(questions) < 2 {
+		return nil
+	}
+	return questions
+}
+
+// ─── QuestionModal ────────────────────────────────────────────────────────────
+
+// QuestionModal presents structured clarifying questions one at a time using a
+// list-fancy style delegate.  The user navigates options with ↑/↓, confirms
+// with Space/Enter, and advances to the next question with Tab.
+type QuestionModal struct {
+	questions   []ParsedQuestion
+	currentQ    int // index of the currently displayed question
+	selections  []int    // selected option index per question (-1 = Other)
+	otherInputs []textarea.Model
+
+	list    list.Model // options for the current question
+	listKeys questionListKeys
+	width   int
+	height  int
+	done    bool
+}
+
+type questionListKeys struct {
+	selectItem key.Binding
+	next       key.Binding
+	prev       key.Binding
+}
+
+func (k questionListKeys) ShortHelp() []key.Binding {
+	return []key.Binding{k.selectItem, k.next}
+}
+func (k questionListKeys) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.selectItem, k.next, k.prev}}
+}
+
+func newQuestionListKeys() questionListKeys {
+	return questionListKeys{
+		selectItem: key.NewBinding(
+			key.WithKeys("enter", " "),
+			key.WithHelp("enter/space", "select"),
+		),
+		next: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next question"),
+		),
+		prev: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "prev question"),
+		),
+	}
+}
+
+// newQuestionDelegate returns a styled list delegate for the question modal.
+func newQuestionDelegate() list.DefaultDelegate {
+	d := list.NewDefaultDelegate()
+	d.ShowDescription = false
+	d.Styles.SelectedTitle = d.Styles.SelectedTitle.
+		Foreground(PrimaryColor).
+		BorderLeftForeground(PrimaryColor)
+	// Normal (unselected) items use muted color
+	d.Styles.NormalTitle = d.Styles.NormalTitle.Foreground(TextColor)
+	return d
+}
+
+// NewQuestionModal creates a new QuestionModal for the given questions.
+func NewQuestionModal(questions []ParsedQuestion) *QuestionModal {
+	keys := newQuestionListKeys()
+
+	// Build "Other" textarea inputs for every question
+	others := make([]textarea.Model, len(questions))
+	for i := range others {
+		ta := textarea.New()
+		ta.Placeholder = "Type your own answer..."
+		ta.CharLimit = 300
+		ta.SetHeight(2)
+		ta.ShowLineNumbers = false
+		ta.Prompt = ""
+		others[i] = ta
+	}
+
+	qm := &QuestionModal{
+		questions:   questions,
+		currentQ:    0,
+		selections:  make([]int, len(questions)),
+		otherInputs: others,
+		listKeys:    keys,
+	}
+	// Default: no selection made yet — use -2 as sentinel
+	for i := range qm.selections {
+		qm.selections[i] = -2
+	}
+
+	qm.list = qm.buildList(0)
+	return qm
+}
+
+// buildList constructs a list.Model for question index qi.
+func (m *QuestionModal) buildList(qi int) list.Model {
+	q := m.questions[qi]
+	items := make([]list.Item, 0, len(q.Options)+1)
+	for _, opt := range q.Options {
+		letter := strings.SplitN(opt, ".", 2)[0]
+		rest := strings.TrimSpace(strings.SplitN(opt, ".", 2)[1])
+		items = append(items, questionOption{letter: letter, text: rest})
+	}
+	// Always add "Other" as last option
+	items = append(items, questionOption{letter: "Other", text: "Type your own answer", isOther: true})
+
+	d := newQuestionDelegate()
+	l := list.New(items, d, m.listWidth(), m.listHeight())
+	l.SetShowTitle(false)
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+	l.SetShowHelp(false)
+	l.SetShowPagination(false)
+	l.KeyMap.Quit = key.NewBinding() // disable q inside modal
+
+	// Restore prior selection if any
+	sel := m.selections[qi]
+	if sel >= 0 && sel < len(items) {
+		l.Select(sel)
+	}
+	return l
+}
+
+func (m *QuestionModal) listWidth() int {
+	w := min(60, m.width-14)
+	if w < 20 {
+		w = 20
+	}
+	return w
+}
+
+func (m *QuestionModal) listHeight() int {
+	// Each item is 1 line + spacing; cap at 10 items visible
+	q := m.questions[m.currentQ]
+	n := len(q.Options) + 1 // +1 for Other
+	if n > 10 {
+		n = 10
+	}
+	return n * 2
+}
+
+// SetSize updates modal dimensions and rebuilds the list.
+func (m *QuestionModal) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.list = m.buildList(m.currentQ)
+	for i := range m.otherInputs {
+		m.otherInputs[i].SetWidth(m.listWidth() - 2)
+	}
+}
+
+// IsDone returns true once all questions are answered and submitted.
+func (m *QuestionModal) IsDone() bool { return m.done }
+
+// BuildAnswer formats all selections into a comma-separated string sent back
+// to Gemini, e.g. "1A, 2C, 3B" or "1A, 2 Other: custom text".
+func (m *QuestionModal) BuildAnswer() string {
+	var parts []string
+	for i, qi := range m.selections {
+		q := m.questions[i]
+		qNum := fmt.Sprintf("%d", i+1)
+		if qi == -1 {
+			// Other
+			other := strings.TrimSpace(m.otherInputs[i].Value())
+			if other == "" {
+				other = "(no answer)"
+			}
+			parts = append(parts, qNum+" Other: "+other)
+		} else if qi >= 0 && qi < len(q.Options) {
+			letter := strings.SplitN(q.Options[qi], ".", 2)[0]
+			parts = append(parts, qNum+letter)
+		} else {
+			// No selection — skip
+			parts = append(parts, qNum+"?")
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// currentOtherSelected returns true if the "Other" option is selected on the
+// current question.
+func (m *QuestionModal) currentOtherSelected() bool {
+	qi := m.currentQ
+	sel := m.selections[qi]
+	return sel == -1
+}
+
+// Update handles input for the question modal.
+func (m *QuestionModal) Update(msg tea.Msg) (*QuestionModal, tea.Cmd) {
+	// If "Other" is selected on current question, route typing into the textarea
+	if m.currentOtherSelected() {
+		switch msg := msg.(type) {
+		case tea.KeyPressMsg:
+			switch msg.String() {
+			case "tab":
+				return m.advance()
+			case "shift+tab":
+				return m.retreat()
+			case "esc":
+				// Deselect Other, go back to list
+				m.selections[m.currentQ] = -2
+				return m, nil
+			}
+			var cmd tea.Cmd
+			m.otherInputs[m.currentQ], cmd = m.otherInputs[m.currentQ].Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.listKeys.next):
+			return m.advance()
+		case key.Matches(msg, m.listKeys.prev):
+			return m.retreat()
+		case key.Matches(msg, m.listKeys.selectItem):
+			if sel, ok := m.list.SelectedItem().(questionOption); ok {
+				if sel.isOther {
+					m.selections[m.currentQ] = -1
+					m.otherInputs[m.currentQ].Focus()
+				} else {
+					// Find option index in the current question's Options slice
+					qOpts := m.questions[m.currentQ].Options
+					for idx, opt := range qOpts {
+						letter := strings.SplitN(opt, ".", 2)[0]
+						if letter == sel.letter {
+							m.selections[m.currentQ] = idx
+							break
+						}
+					}
+				}
+			}
+			return m.advance()
+		case msg.String() == "esc":
+			// Esc closes modal with whatever has been answered so far
+			m.done = true
+			return m, nil
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// advance moves to next question or marks done if on the last question.
+func (m *QuestionModal) advance() (*QuestionModal, tea.Cmd) {
+	if m.currentQ < len(m.questions)-1 {
+		m.currentQ++
+		m.list = m.buildList(m.currentQ)
+	} else {
+		m.done = true
+	}
+	return m, nil
+}
+
+// retreat moves back to the previous question.
+func (m *QuestionModal) retreat() (*QuestionModal, tea.Cmd) {
+	if m.currentQ > 0 {
+		m.currentQ--
+		m.list = m.buildList(m.currentQ)
+	}
+	return m, nil
+}
+
+// Render draws the centered question modal overlay.
+func (m *QuestionModal) Render() string {
+	innerW := m.listWidth()
+	q := m.questions[m.currentQ]
+
+	var b strings.Builder
+
+	// ── Title + progress ─────────────────────────────────────────────────────
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(PrimaryColor)
+	b.WriteString(titleStyle.Render("Clarifying Questions"))
+	b.WriteString("\n")
+	b.WriteString(DividerStyle.Render(strings.Repeat("─", innerW)))
+	b.WriteString("\n")
+	progressStyle := lipgloss.NewStyle().Foreground(MutedColor)
+	b.WriteString(progressStyle.Render(fmt.Sprintf(
+		"Question %d of %d", m.currentQ+1, len(m.questions),
+	)))
+	b.WriteString("\n\n")
+
+	// ── Question text ─────────────────────────────────────────────────────────
+	qStyle := lipgloss.NewStyle().Foreground(TextColor).Bold(true).Width(innerW)
+	b.WriteString(qStyle.Render(q.Text))
+	b.WriteString("\n")
+	b.WriteString(DividerStyle.Render(strings.Repeat("─", innerW)))
+	b.WriteString("\n")
+
+	// ── Options list ──────────────────────────────────────────────────────────
+	if m.currentOtherSelected() {
+		// Show the textarea for "Other"
+		otherLabel := lipgloss.NewStyle().Foreground(PrimaryColor).Render("Other: ")
+		b.WriteString(otherLabel)
+		b.WriteString("\n")
+		b.WriteString(m.otherInputs[m.currentQ].View())
+		b.WriteString("\n")
+	} else {
+		b.WriteString(m.list.View())
+	}
+
+	// ── Current selection indicator ───────────────────────────────────────────
+	sel := m.selections[m.currentQ]
+	if sel >= 0 && sel < len(q.Options) {
+		selStyle := lipgloss.NewStyle().Foreground(SuccessColor)
+		letter := strings.SplitN(q.Options[sel], ".", 2)[0]
+		b.WriteString("\n")
+		b.WriteString(selStyle.Render("✓ Selected: " + letter))
+		b.WriteString("\n")
+	} else if sel == -1 {
+		selStyle := lipgloss.NewStyle().Foreground(SuccessColor)
+		b.WriteString("\n")
+		b.WriteString(selStyle.Render("✓ Selected: Other"))
+		b.WriteString("\n")
+	}
+
+	// ── Footer ────────────────────────────────────────────────────────────────
+	b.WriteString("\n")
+	b.WriteString(DividerStyle.Render(strings.Repeat("─", innerW)))
+	b.WriteString("\n")
+	footStyle := lipgloss.NewStyle().Foreground(MutedColor)
+	var footText string
+	if m.currentQ == len(m.questions)-1 {
+		footText = "↑/↓ Navigate   Enter/Space Select+Submit   Shift+Tab Back   Esc Dismiss"
+	} else {
+		footText = "↑/↓ Navigate   Enter/Space Select+Next   Shift+Tab Back   Esc Dismiss"
+	}
+	b.WriteString(footStyle.Render(footText))
+
+	// ── Modal box ─────────────────────────────────────────────────────────────
+	modalWidth := innerW + 8 // account for padding + border
+	modalStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(PrimaryColor).
+		Padding(1, 3).
+		Width(modalWidth)
+
+	modal := modalStyle.Render(b.String())
+	return m.centerModal(modal)
+}
+
+func (m *QuestionModal) centerModal(modal string) string {
+	lines := strings.Split(modal, "\n")
+	mh := len(lines)
+	mw := 0
+	for _, l := range lines {
+		if w := lipgloss.Width(l); w > mw {
+			mw = w
+		}
+	}
+	top := (m.height - mh) / 2
+	left := (m.width - mw) / 2
+	if top < 0 {
+		top = 0
+	}
+	if left < 0 {
+		left = 0
+	}
+	var out strings.Builder
+	pad := strings.Repeat(" ", left)
+	for i := 0; i < top; i++ {
+		out.WriteString("\n")
+	}
+	for _, line := range lines {
+		out.WriteString(pad)
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+	return out.String()
+}

--- a/internal/tui/question_modal.go
+++ b/internal/tui/question_modal.go
@@ -111,11 +111,12 @@ type QuestionModal struct {
 	selections  []int    // selected option index per question (-1 = Other)
 	otherInputs []textarea.Model
 
-	list    list.Model // options for the current question
-	listKeys questionListKeys
-	width   int
-	height  int
-	done    bool
+	list      list.Model // options for the current question
+	listKeys  questionListKeys
+	width     int
+	height    int
+	done      bool
+	cancelled bool
 }
 
 type questionListKeys struct {
@@ -278,6 +279,11 @@ func (m *QuestionModal) BuildAnswer() string {
 	return strings.Join(parts, ", ")
 }
 
+// Cancelled returns true if the user pressed Esc to dismiss the modal.
+func (m *QuestionModal) Cancelled() bool {
+	return m.cancelled
+}
+
 // currentOtherSelected returns true if the "Other" option is selected on the
 // current question.
 func (m *QuestionModal) currentOtherSelected() bool {
@@ -321,6 +327,7 @@ func (m *QuestionModal) Update(msg tea.Msg) (*QuestionModal, tea.Cmd) {
 				if sel.isOther {
 					m.selections[m.currentQ] = -1
 					m.otherInputs[m.currentQ].Focus()
+					return m, nil // Stay on this question so user can type
 				} else {
 					// Find option index in the current question's Options slice
 					qOpts := m.questions[m.currentQ].Options
@@ -335,8 +342,9 @@ func (m *QuestionModal) Update(msg tea.Msg) (*QuestionModal, tea.Cmd) {
 			}
 			return m.advance()
 		case msg.String() == "esc":
-			// Esc closes modal with whatever has been answered so far
+			// Esc cancels — caller should check Cancelled() before using BuildAnswer()
 			m.done = true
+			m.cancelled = true
 			return m, nil
 		}
 	}

--- a/internal/tui/question_modal_test.go
+++ b/internal/tui/question_modal_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import "testing"
+
+// ── Fix 4: ParseQuestions hardening tests ────────────────────────────────────
+
+func TestParseQuestions_ValidQABlock(t *testing.T) {
+	text := `1. What framework should we use?
+   A. React
+   B. Vue
+   C. Angular
+
+2. What database do you prefer?
+   A. PostgreSQL
+   B. MySQL
+   C. SQLite`
+
+	questions := ParseQuestions(text)
+	if questions == nil {
+		t.Fatal("expected questions to be parsed")
+	}
+	if len(questions) != 2 {
+		t.Fatalf("expected 2 questions, got %d", len(questions))
+	}
+	// Verify question text is extracted correctly (minus the numbering)
+	if questions[0].Text != "What framework should we use?" {
+		t.Errorf("unexpected q1 text: %q", questions[0].Text)
+	}
+	if len(questions[0].Options) != 3 {
+		t.Errorf("expected 3 options for q1, got %d", len(questions[0].Options))
+	}
+	if len(questions[1].Options) != 3 {
+		t.Errorf("expected 3 options for q2, got %d", len(questions[1].Options))
+	}
+}
+
+func TestParseQuestions_SingleQuestion_ReturnsNil(t *testing.T) {
+	text := `1. What framework should we use?
+   A. React
+   B. Vue`
+
+	questions := ParseQuestions(text)
+	if questions != nil {
+		t.Errorf("expected nil for single question, got %d questions", len(questions))
+	}
+}
+
+func TestParseQuestions_NumberedListWithoutQuestions(t *testing.T) {
+	// This is a numbered implementation plan — no question marks
+	text := `1. Set up the project structure
+   a. Create the src directory
+   b. Initialize package.json
+
+2. Implement the API endpoints
+   a. Create the user controller
+   b. Add validation middleware
+
+3. Write integration tests
+   a. Set up test database
+   b. Create test fixtures`
+
+	questions := ParseQuestions(text)
+	if questions != nil {
+		t.Errorf("expected nil for numbered implementation steps (no question marks), got %d", len(questions))
+	}
+}
+
+func TestParseQuestions_EmptyText(t *testing.T) {
+	questions := ParseQuestions("")
+	if questions != nil {
+		t.Error("expected nil for empty text")
+	}
+}
+
+func TestParseQuestions_PlainProse(t *testing.T) {
+	text := "This is just regular text without any numbered questions or options."
+	questions := ParseQuestions(text)
+	if questions != nil {
+		t.Error("expected nil for plain prose")
+	}
+}
+
+func TestParseQuestions_QuestionsWithQuestionMarks(t *testing.T) {
+	text := `1. What authentication method should we use?
+   A. JWT tokens
+   B. Session cookies
+
+2. Should we implement rate limiting?
+   A. Yes, with Redis
+   B. No, defer to later`
+
+	questions := ParseQuestions(text)
+	if questions == nil {
+		t.Fatal("expected questions to be parsed for valid Q&A with question marks")
+	}
+	if len(questions) != 2 {
+		t.Fatalf("expected 2 questions, got %d", len(questions))
+	}
+}
+
+func TestParseQuestions_MixedContentWithSomeQuestionMarks(t *testing.T) {
+	// Only 1 actual question, rest are statements — should return nil
+	text := `1. What approach should we take?
+   A. Option A
+   B. Option B
+
+2. Implement the solution
+   a. First step
+   b. Second step`
+
+	// The second item has no question mark, so overall count of
+	// "questions with ?" is only 1 — should return nil
+	questions := ParseQuestions(text)
+	if questions != nil {
+		t.Errorf("expected nil when only 1 actual question, got %d", len(questions))
+	}
+}
+
+func TestParseQuestions_MalformedInput(t *testing.T) {
+	text := "1. \n   A. "
+	questions := ParseQuestions(text)
+	if questions != nil {
+		t.Error("expected nil for malformed input")
+	}
+}

--- a/internal/tui/question_modal_test.go
+++ b/internal/tui/question_modal_test.go
@@ -1,6 +1,10 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
 
 // ── Fix 4: ParseQuestions hardening tests ────────────────────────────────────
 
@@ -122,4 +126,86 @@ func TestParseQuestions_MalformedInput(t *testing.T) {
 	if questions != nil {
 		t.Error("expected nil for malformed input")
 	}
+}
+
+// ── Arrow key navigation tests ────────────────────────────────────────────────
+
+// testQuestionsText returns a standard two-question block for use in tests.
+func testQuestionsText() string {
+return `1. What framework should we use?
+   A. React
+   B. Vue
+   C. Angular
+
+2. What database do you prefer?
+   A. PostgreSQL
+   B. MySQL`
+}
+
+// TestQuestionModal_ArrowKeysNavigateList verifies that pressing "down" moves
+// the list cursor and that the cursor position is NOT reset on the next render
+// (i.e. SetSize does not rebuild the list and wipe out cursor state).
+func TestQuestionModal_ArrowKeysNavigateList(t *testing.T) {
+qs := ParseQuestions(testQuestionsText())
+if qs == nil {
+t.Fatal("test requires valid questions")
+}
+m := NewQuestionModal(qs)
+m.SetSize(80, 24)
+
+// Initial cursor should be at index 0
+if m.list.Index() != 0 {
+t.Fatalf("expected initial cursor at 0, got %d", m.list.Index())
+}
+
+// Press "down" — should move cursor to index 1
+downMsg := tea.KeyPressMsg{Code: tea.KeyDown}
+m, _ = m.Update(downMsg)
+if m.list.Index() != 1 {
+t.Fatalf("expected cursor at 1 after down key, got %d", m.list.Index())
+}
+
+// Simulate what View() used to do: call SetSize again (this was the bug)
+// The cursor must NOT be reset to 0 after SetSize.
+m.SetSize(80, 24)
+if m.list.Index() != 1 {
+t.Fatalf("cursor should stay at 1 after SetSize, got %d (SetSize must not rebuild the list)", m.list.Index())
+}
+
+// Press "up" — should move cursor back to index 0
+upMsg := tea.KeyPressMsg{Code: tea.KeyUp}
+m, _ = m.Update(upMsg)
+if m.list.Index() != 0 {
+t.Fatalf("expected cursor at 0 after up key, got %d", m.list.Index())
+}
+}
+
+// TestQuestionModal_SetSizeDoesNotResetCursor is a focused regression test
+// for the bug where SetSize rebuilt the list, losing the cursor position.
+func TestQuestionModal_SetSizeDoesNotResetCursor(t *testing.T) {
+qs := ParseQuestions(testQuestionsText())
+if qs == nil {
+t.Fatal("test requires valid questions")
+}
+m := NewQuestionModal(qs)
+m.SetSize(80, 24)
+
+// Move cursor down twice
+downMsg := tea.KeyPressMsg{Code: tea.KeyDown}
+m, _ = m.Update(downMsg)
+m, _ = m.Update(downMsg)
+
+wantIdx := m.list.Index()
+if wantIdx == 0 {
+t.Fatal("cursor did not move after two down key presses")
+}
+
+// Call SetSize multiple times (simulating repeated View() calls)
+for i := 0; i < 5; i++ {
+m.SetSize(80, 24)
+}
+
+if m.list.Index() != wantIdx {
+t.Errorf("cursor was reset by SetSize: want %d, got %d", wantIdx, m.list.Index())
+}
 }

--- a/internal/tui/quit_confirm.go
+++ b/internal/tui/quit_confirm.go
@@ -139,42 +139,5 @@ func (q *QuitConfirmation) Render() string {
 	modal := modalStyle.Render(content.String())
 
 	// Center on screen
-	return q.centerModal(modal)
-}
-
-// centerModal centers the modal on the screen.
-func (q *QuitConfirmation) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	modalHeight := len(lines)
-	modalWidth := 0
-	for _, line := range lines {
-		if lipgloss.Width(line) > modalWidth {
-			modalWidth = lipgloss.Width(line)
-		}
-	}
-
-	topPadding := (q.height - modalHeight) / 2
-	leftPadding := (q.width - modalWidth) / 2
-
-	if topPadding < 0 {
-		topPadding = 0
-	}
-	if leftPadding < 0 {
-		leftPadding = 0
-	}
-
-	var result strings.Builder
-
-	for i := 0; i < topPadding; i++ {
-		result.WriteString("\n")
-	}
-
-	leftPad := strings.Repeat(" ", leftPadding)
-	for _, line := range lines {
-		result.WriteString(leftPad)
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return result.String()
+	return CenterModal(modal, q.width, q.height)
 }

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -251,7 +251,7 @@ func (s *SettingsOverlay) Render() string {
 
 	modal := modalStyle.Render(content.String())
 
-	return centerModal(modal, s.width, s.height)
+	return CenterModal(modal, s.width, s.height)
 }
 
 // renderItems renders the settings items grouped by section.

--- a/internal/tui/worktree_spinner.go
+++ b/internal/tui/worktree_spinner.go
@@ -240,41 +240,5 @@ func (w *WorktreeSpinner) Render() string {
 
 	modal := modalStyle.Render(content.String())
 
-	return w.centerModal(modal)
-}
-
-// centerModal centers the modal on the screen.
-func (w *WorktreeSpinner) centerModal(modal string) string {
-	lines := strings.Split(modal, "\n")
-	modalHeight := len(lines)
-	modalWidth := 0
-	for _, line := range lines {
-		if lipgloss.Width(line) > modalWidth {
-			modalWidth = lipgloss.Width(line)
-		}
-	}
-
-	topPadding := (w.height - modalHeight) / 2
-	leftPadding := (w.width - modalWidth) / 2
-
-	if topPadding < 0 {
-		topPadding = 0
-	}
-	if leftPadding < 0 {
-		leftPadding = 0
-	}
-
-	var result strings.Builder
-	for i := 0; i < topPadding; i++ {
-		result.WriteString("\n")
-	}
-
-	leftPad := strings.Repeat(" ", leftPadding)
-	for _, line := range lines {
-		result.WriteString(leftPad)
-		result.WriteString(line)
-		result.WriteString("\n")
-	}
-
-	return result.String()
+	return CenterModal(modal, w.width, w.height)
 }


### PR DESCRIPTION
**1. Error modal (any error, 3 consecutive without progress)**
- Add `EventRateLimit` event type to loop/parser.go
- Detect rate-limit/quota patterns in Gemini stderr; emit EventRateLimit and auto-stop the loop (loop/loop.go)
- New `ErrorModal` component (tui/error_modal.go) using charm.land/bubbles/v2 list-fancy delegate with title/description rows
- Title: "Oops! / Looks like we hit a snag... / {error}"
- Options: "Save and quit (Recommended)", "Stop loop", "Continue anyway"
- Wired into app.go: rate-limit always shows modal; other errors show after 3 consecutive failures without a story completing between them (`consecutiveErrors` map reset on `EventStoryCompleted`)

**2. Dashboard details panel — bubbles viewport**
- Replace manual `detailsScrollOffset int` + line-slicing with a proper `viewport.Model` (tui/app.go, tui/dashboard.go)
- PgUp/PgDn now call `HalfPageUp/HalfPageDown`; story navigation resets viewport to top; switchToPRD also resets to top

**3. Persistent TUI logs**
- Add `SaveEntries`, `LoadEntries`, `AppendEntry` to `LogViewer` (tui/log.go) serialising/deserialising entries as JSONL at `.melliza/prds/<name>/tui_log.jsonl`
- app.go `switchToPRD`: saves current PRD log before clearing, loads the new PRD's prior log immediately after — logs survive tab switches
- Each new event is appended to disk in real-time (append-only, no full rewrite)

**4. Clarifying questions — list-fancy modal overlay**
- New `QuestionModal` component (tui/question_modal.go):
  - `ParseQuestions(text)` regex-extracts numbered Q&A blocks from Gemini's markdown (≥2 questions required to trigger the modal)
  - Wizard-style: one question at a time, options rendered as a list-fancy delegate (highlighted selected title, description-less)
  - "Other" option switches to a textarea input for free text
  - Tab/Shift+Tab navigate between questions; Enter/Space selects + advances
  - `BuildAnswer()` formats as "1A, 2C, 3 Other: custom text"
- Wired into creation.go: after each assistant message the content is parsed; if questions are detected the modal intercepts all key events and submits the compiled answer back to Gemini via `SendMessage`

https://claude.ai/code/session_01QjvSRMcaRrq2z2L4yrxii5